### PR TITLE
Implement color clock obj

### DIFF
--- a/sw/arduino/retry-color-clock/alpha-display.cpp
+++ b/sw/arduino/retry-color-clock/alpha-display.cpp
@@ -19,9 +19,9 @@ void AlphaDisplay::write_display_time(byte hr, byte min, byte sec){
 
 
 void AlphaDisplay::write_flux_to_display(){
-  led_segments.writeDigitAscii(0, 'F');
+  led_segments.writeDigitAscii(0, 'B');
   led_segments.writeDigitAscii(1, 'L');
-  led_segments.writeDigitAscii(2, 'U');
-  led_segments.writeDigitAscii(3, 'X');
+  led_segments.writeDigitAscii(2, 'E');
+  led_segments.writeDigitAscii(3, 'H');
   led_segments.writeDisplay();
 }

--- a/sw/arduino/retry-color-clock/alpha-display.cpp
+++ b/sw/arduino/retry-color-clock/alpha-display.cpp
@@ -4,26 +4,24 @@
 
 #include "alpha-display.hpp"
 
-Adafruit_AlphaNum4 AlphaDisplay::the_alpha_display = Adafruit_AlphaNum4();
-
 //------------------------------------------------------------------------------
 // Write the time to the alphanumeric display
 //------------------------------------------------------------------------------
 void AlphaDisplay::write_display_time(byte hr, byte min, byte sec){
 
-  the_alpha_display.writeDigitAscii(3, 0x30 + sec % 10);
-  the_alpha_display.writeDigitAscii(2, 0x30 + sec / 10);
-  the_alpha_display.writeDigitAscii(1, 0x30 + min % 10);
-  the_alpha_display.writeDigitAscii(0, 0x30 + min / 10);
+  led_segments.writeDigitAscii(3, 0x30 + sec % 10);
+  led_segments.writeDigitAscii(2, 0x30 + sec / 10);
+  led_segments.writeDigitAscii(1, 0x30 + min % 10);
+  led_segments.writeDigitAscii(0, 0x30 + min / 10);
 
-  the_alpha_display.writeDisplay();
+  led_segments.writeDisplay();
 }
 
 
 void AlphaDisplay::write_flux_to_display(){
-  the_alpha_display.writeDigitAscii(0, 'F');
-  the_alpha_display.writeDigitAscii(1, 'L');
-  the_alpha_display.writeDigitAscii(2, 'U');
-  the_alpha_display.writeDigitAscii(3, 'X');
-  the_alpha_display.writeDisplay();
+  led_segments.writeDigitAscii(0, 'F');
+  led_segments.writeDigitAscii(1, 'L');
+  led_segments.writeDigitAscii(2, 'U');
+  led_segments.writeDigitAscii(3, 'X');
+  led_segments.writeDisplay();
 }

--- a/sw/arduino/retry-color-clock/alpha-display.hpp
+++ b/sw/arduino/retry-color-clock/alpha-display.hpp
@@ -2,6 +2,8 @@
 // DESCRIPTION
 // This class contains functionality for the alphanumeric display.
 //------------------------------------------------------------------------------
+#ifndef ALPHA_DISPLAY
+#define ALPHA_DISPLAY
 
 #include <Adafruit_GFX.h>
 #include "Adafruit_LEDBackpack.h"
@@ -10,8 +12,10 @@ class AlphaDisplay{
 
 public:
 
-  static Adafruit_AlphaNum4 the_alpha_display;
+  Adafruit_AlphaNum4 led_segments;
 
-  static void write_display_time(byte hr, byte min, byte sec);
-  static void write_flux_to_display();
+  void write_display_time(byte hr, byte min, byte sec);
+  void write_flux_to_display();
 };
+
+#endif

--- a/sw/arduino/retry-color-clock/color-clock.cpp
+++ b/sw/arduino/retry-color-clock/color-clock.cpp
@@ -1,0 +1,18 @@
+#include "color-clock.hpp"
+
+RgbColor ColorClock::ABS_RGB_RED = RgbColor(0xFF0000);
+RgbColor ColorClock::ABS_RGB_YEL = RgbColor(0xFFFF00);
+RgbColor ColorClock::ABS_RGB_GRN = RgbColor(0x00FF00);
+RgbColor ColorClock::ABS_RGB_CYA = RgbColor(0x00FFFF);
+RgbColor ColorClock::ABS_RGB_BLU = RgbColor(0xFF00FF);
+RgbColor ColorClock::ABS_RGB_MAG = RgbColor(0xFF00FF);
+
+ColorClock::ColorClock(){
+  this->color_selection[0] = ABS_RGB_RED;
+  this->color_selection[1] = ABS_RGB_YEL;
+  this->color_selection[2] = ABS_RGB_GRN;
+  this->color_selection[3] = ABS_RGB_CYA;
+  this->color_selection[4] = ABS_RGB_BLU;
+  this->color_selection[5] = ABS_RGB_MAG;
+  
+}

--- a/sw/arduino/retry-color-clock/color-clock.hpp
+++ b/sw/arduino/retry-color-clock/color-clock.hpp
@@ -17,11 +17,25 @@
 #include "logic.hpp"
 #include "time-calcs.hpp"
 
+#define CYCLE_PARTITIONS 6
+
 class ColorClock{
 
 public:
+  int cycle_partitions;
+
+  // when mapping the time to color, a time will fall between
+  // two indices of the color times. These variables are the
+  // indices that the current time falls between.
+  int lo_color_index;                        
+  int hi_color_index;
 
   AlphaDisplay the_alpha_display;
   DS3231       the_rtc;
+  RgbColor     color_selection[CYCLE_PARTITIONS];
+  float        color_times[CYCLE_PARTITIONS];
 
+  ColorClock(){};
+  RgbColor time_to_color();
+  void     determine_color_indices();
 };

--- a/sw/arduino/retry-color-clock/color-clock.hpp
+++ b/sw/arduino/retry-color-clock/color-clock.hpp
@@ -3,6 +3,9 @@
 // This file contains the class for a color clock object.
 //------------------------------------------------------------------------------
 
+#ifndef COLOR_CLOCK
+#define COLOR_CLOCK
+
 //------------------------------------------------------------------------------
 #include <Arduino.h>
 #include <Wire.h>
@@ -24,9 +27,9 @@ class ColorClock{
 public:
   int cycle_partitions;
 
-  // when mapping the time to color, a time will fall between
-  // two indices of the color times. These variables are the
-  // indices that the current time falls between.
+  // The sampled time will fall bewtween two indices of
+  // color_times. These variables are the
+  // indices that the time falls between.
   int lo_color_index;                        
   int hi_color_index;
 
@@ -35,7 +38,18 @@ public:
   RgbColor     color_selection[CYCLE_PARTITIONS];
   float        color_times[CYCLE_PARTITIONS];
 
-  ColorClock(){};
+  // RGB constants
+  static RgbColor ABS_RGB_RED;
+  static RgbColor ABS_RGB_YEL;
+  static RgbColor ABS_RGB_GRN;
+  static RgbColor ABS_RGB_CYA;
+  static RgbColor ABS_RGB_BLU;
+  static RgbColor ABS_RGB_MAG;
+
+  ColorClock();
+
   RgbColor time_to_color();
   void     determine_color_indices();
 };
+
+#endif

--- a/sw/arduino/retry-color-clock/color-clock.hpp
+++ b/sw/arduino/retry-color-clock/color-clock.hpp
@@ -1,0 +1,27 @@
+//------------------------------------------------------------------------------
+// DESCRIPTION
+// This file contains the class for a color clock object.
+//------------------------------------------------------------------------------
+
+//------------------------------------------------------------------------------
+#include <Arduino.h>
+#include <Wire.h>
+
+#include <Adafruit_GFX.h>
+#include "Adafruit_LEDBackpack.h"
+#include <DS3231.h>
+
+#include "alpha-display.hpp"
+#include "classes.hpp"
+#include "debug.hpp"
+#include "logic.hpp"
+#include "time-calcs.hpp"
+
+class ColorClock{
+
+public:
+
+  AlphaDisplay the_alpha_display;
+  DS3231       the_rtc;
+
+};

--- a/sw/arduino/retry-color-clock/retry-color-clock.ino
+++ b/sw/arduino/retry-color-clock/retry-color-clock.ino
@@ -12,11 +12,7 @@
 #include "logic.hpp"
 #include "time-calcs.hpp"
 
-#define DEBUG 0
-
 ColorClock the_first_colorclock;
-
-DS3231 the_first_rtc;
 
 byte set_hr    = 13;
 byte set_min   = 54;
@@ -40,9 +36,6 @@ void loop(){
 
   // initialize clock
   if (first_run == true) {
-    the_first_rtc.setHour(set_hr);
-    the_first_rtc.setMinute(set_min);
-
     the_first_colorclock.the_rtc.setHour(set_hr);
     the_first_colorclock.the_rtc.setMinute(set_min);
     first_run = false;

--- a/sw/arduino/retry-color-clock/retry-color-clock.ino
+++ b/sw/arduino/retry-color-clock/retry-color-clock.ino
@@ -7,11 +7,14 @@
 
 #include "alpha-display.hpp"
 #include "classes.hpp"
+#include "color-clock.hpp"
 #include "debug.hpp"
 #include "logic.hpp"
 #include "time-calcs.hpp"
 
 #define DEBUG 0
+
+ColorClock the_first_colorclock;
 
 DS3231 the_first_rtc;
 
@@ -23,7 +26,7 @@ bool first_run = true;
 //------------------------------------------------------------------------------
 void setup(){
   Serial.begin(9600);
-  AlphaDisplay::the_alpha_display.begin(0x70);
+  the_first_colorclock.the_alpha_display.led_segments.begin(0x70);
   Wire.begin();
 
   // left off here - don't know why I can't see these
@@ -39,13 +42,14 @@ void loop(){
   if (first_run == true) {
     the_first_rtc.setHour(set_hr);
     the_first_rtc.setMinute(set_min);
+
+    the_first_colorclock.the_rtc.setHour(set_hr);
+    the_first_colorclock.the_rtc.setMinute(set_min);
     first_run = false;
   }
 
-  
-
-  Debug::print_time(the_first_rtc);
-  AlphaDisplay::write_flux_to_display();
+  Debug::print_time(the_first_colorclock.the_rtc);
+  the_first_colorclock.the_alpha_display.write_flux_to_display();
 
   delay(1000);
 }


### PR DESCRIPTION
Implemented a ColorClock object that contains members for an rtc clock and alpha numeric display.

I decided to implement a color clock object that would contain the logic for mapping the time to color to open the possibility of a project containing more than one colorclock in the future.